### PR TITLE
Add configuration setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ Collection of scripts and configuration files for building Asterisk.
 - `asterisk20-install.sh` – Install Asterisk 20 on Debian 12.
 - `asterisk20-bookworm-pi-install.sh` – Install Asterisk 20 on Raspberry Pi OS Bookworm.
 
+## Configuration
+
+After running one of the install scripts, copy the example configuration files to `/etc/asterisk`:
+
+```bash
+sudo cp config/*.conf /etc/asterisk/
+```
+
+Edit `/etc/asterisk/pjsip.conf` and replace the placeholder values:
+
+- Set the password fields under `[yealink-auth]` and `[zoiper-auth]` to match the credentials used by your Yealink phone and Zoiper softphone.
+- Provide your SIPGate account information in `[sipgate-trunk]` and `[sipgate-auth]` (username, password and client URI).
+
+Make sure your phones register with the usernames defined in these sections (`yealink-t42s` and `zoiper`).

--- a/asterisk20-bookworm-pi-install.sh
+++ b/asterisk20-bookworm-pi-install.sh
@@ -89,8 +89,14 @@ echo "Step 12: Enabling and starting Asterisk service..."
 sudo systemctl enable asterisk
 sudo systemctl start asterisk
 
+# Installing configuration templates
+echo "Step 13: Installing configuration templates..."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+sudo cp "$SCRIPT_DIR"/config/*.conf /etc/asterisk/
+sudo chown asterisk:asterisk /etc/asterisk/*.conf
+
 # Verifying Operation
-echo "Step 13: Verifying Asterisk operation..."
+echo "Step 14: Verifying Asterisk operation..."
 echo "To connect to the Asterisk CLI, run: sudo asterisk -rvvv"
 echo "You should see output similar to:"
 echo "Asterisk 20.X.X, Copyright (C) 1999 - 2025 Sangoma, Inc."

--- a/asterisk20-install.sh
+++ b/asterisk20-install.sh
@@ -84,8 +84,14 @@ echo "Step 12: Enabling and starting Asterisk service..."
 sudo systemctl enable asterisk
 sudo systemctl start asterisk
 
+# Installing configuration templates
+echo "Step 13: Installing configuration templates..."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+sudo cp "$SCRIPT_DIR"/config/*.conf /etc/asterisk/
+sudo chown asterisk:asterisk /etc/asterisk/*.conf
+
 # Verifying Operation
-echo "Step 13: Verifying Asterisk operation..."
+echo "Step 14: Verifying Asterisk operation..."
 echo "To connect to the Asterisk CLI, run: sudo asterisk -rvvv"
 echo "You should see output similar to:"
 echo "Asterisk 20.X.X, Copyright (C) 1999 - 2025 Sangoma, Inc."


### PR DESCRIPTION
## Summary
- add instructions for copying config templates after install
- automate copying configs in install scripts

## Testing
- `shellcheck asterisk-install/asterisk20-install.sh asterisk-install/asterisk20-bookworm-pi-install.sh`
- `sudo apt-get update`
- `sudo apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_6848240498d08323a2612c8280f09c28