### PR TITLE
Install dynamic IVR with database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ sudo ./setup-asterisk.sh --debian   # Debian based systems
 sudo ./setup-asterisk.sh --pi       # Raspberry Pi OS
 ```
 
-The script installs Asterisk 20, copies the configuration files to `/etc/asterisk` and places the AGI scripts under `/var/lib/asterisk/agi-bin`.
+The script installs Asterisk 20, copies the configuration files to `/etc/asterisk`,
+places the AGI scripts under `/var/lib/asterisk/agi-bin`, and deploys the
+Dynamic IVR project with its dependencies.
 
 ## Configuration
 
@@ -32,3 +34,14 @@ After modifying the files, reload the Asterisk service so the changes take effec
 ## Running the IVR
 
 The demo IVR script is installed as `/var/lib/asterisk/agi-bin/ivr/demo_ivr.py` and is invoked by extension `250` in `extensions.conf`. Dial `250` from one of the configured phones to test it. The IVR configuration files can be found in `/var/lib/asterisk/agi-bin/ivr/config`.
+
+### Dynamic IVR with LLM
+
+This repository's setup script also deploys Brownster's [Dynamic IVR with LLM Integration](https://github.com/Brownster/asterisk-ivr).
+The project is cloned to `/var/lib/asterisk/agi-bin/asterisk-ivr` and the Python
+dependencies are installed automatically. A local MariaDB database named
+`freepbx_llm` is created along with a `freepbx_user` account. Update the
+credentials in `asterisk-ivr/config/db_config.yml.yaml` if needed.
+
+The new IVR can be tested by dialing extension `260` once the installation
+completes.

--- a/config/extensions.conf
+++ b/config/extensions.conf
@@ -26,6 +26,12 @@ exten => 250,n,Verbose(1,Running demo IVR script)
 exten => 250,n,AGI(ivr/demo_ivr.py)
 exten => 250,n,Hangup()
 
+; Dynamic IVR with LLM Integration
+exten => 260,1,Answer()
+exten => 260,n,Verbose(1,Running dynamic IVR)
+exten => 260,n,AGI(asterisk-ivr/src/ivr/agi_handler.py)
+exten => 260,n,Hangup()
+
 ; Dial out through mobile phone
 exten => _9.,1,Dial(Mobile/mobile-trunk/${EXTEN:1})
 exten => _9.,n,Hangup()

--- a/setup-asterisk.sh
+++ b/setup-asterisk.sh
@@ -32,4 +32,23 @@ sudo mkdir -p /var/lib/asterisk/agi-bin
 sudo cp -r "$SCRIPT_DIR"/agi-scripts/* /var/lib/asterisk/agi-bin/
 sudo chown -R asterisk:asterisk /var/lib/asterisk/agi-bin
 
+# Install Dynamic IVR with LLM integration
+echo "Installing Dynamic IVR..."
+sudo apt-get install -y python3-pip python3-venv mariadb-server git
+if [ ! -d /var/lib/asterisk/agi-bin/asterisk-ivr ]; then
+    sudo git clone https://github.com/Brownster/asterisk-ivr.git \
+        /var/lib/asterisk/agi-bin/asterisk-ivr
+fi
+sudo chown -R asterisk:asterisk /var/lib/asterisk/agi-bin/asterisk-ivr
+sudo pip3 install -r /var/lib/asterisk/agi-bin/asterisk-ivr/requirements.txt
+
+# Create database for the IVR
+echo "Setting up MariaDB database for IVR..."
+sudo mysql <<'EOF'
+CREATE DATABASE IF NOT EXISTS freepbx_llm;
+CREATE USER IF NOT EXISTS 'freepbx_user'@'localhost' IDENTIFIED BY 'secure_password';
+GRANT ALL PRIVILEGES ON freepbx_llm.* TO 'freepbx_user'@'localhost';
+FLUSH PRIVILEGES;
+EOF
+
 echo "Setup complete. Edit /etc/asterisk/pjsip.conf and chan_mobile.conf to set your credentials."


### PR DESCRIPTION
## Summary
- deploy Brownster dynamic IVR as part of the install process
- add MariaDB setup and Python dependency installation
- register new IVR extension in `extensions.conf`
- document the new functionality in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68486d0dcec4832388ab13d7cd120735