### PR TITLE
Implement guided setup via settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Collection of scripts and configuration files for building Asterisk.
 
 ## Installation
 
-Run the wrapper script with `sudo` and specify the target system:
+First copy `config/settings.sample` to `config/settings.conf` and edit the values for
+your phones, SIP trunk and Bluetooth settings. Then run the wrapper script with `sudo`
+and specify the target system:
 
 ```bash
 sudo ./setup-asterisk.sh --debian   # Debian based systems
@@ -22,14 +24,8 @@ Dynamic IVR project with its dependencies.
 
 ## Configuration
 
-Edit `/etc/asterisk/pjsip.conf` and replace the placeholder values:
-
-- Update the passwords in `[yealink-auth]` and `[zoiper-auth]` to match your phone credentials.
-- Provide your SIPGate account details in `[sipgate-trunk]` and `[sipgate-auth]` (`client_uri`, `username`, `password`).
-
-Edit `/etc/asterisk/chan_mobile.conf` and set the Bluetooth adapter and mobile phone addresses for your environment.
-
-After modifying the files, reload the Asterisk service so the changes take effect.
+All configuration values are stored in `config/settings.conf`. Update this file with the
+credentials for your phones, SIP trunk and Bluetooth trunk before running the installer.
 
 ## Running the IVR
 
@@ -40,8 +36,9 @@ The demo IVR script is installed as `/var/lib/asterisk/agi-bin/ivr/demo_ivr.py` 
 This repository's setup script also deploys Brownster's [Dynamic IVR with LLM Integration](https://github.com/Brownster/asterisk-ivr).
 The project is cloned to `/var/lib/asterisk/agi-bin/asterisk-ivr` and the Python
 dependencies are installed automatically. A local MariaDB database named
-`freepbx_llm` is created along with a `freepbx_user` account. Update the
-credentials in `asterisk-ivr/config/db_config.yml.yaml` if needed.
+`freepbx_llm` is created along with a `freepbx_user` account whose password is
+set from `DB_PASSWORD` in `config/settings.conf`. Update the credentials in
+`asterisk-ivr/config/db_config.yml.yaml` if needed.
 
 The new IVR can be tested by dialing extension `260` once the installation
 completes.

--- a/asterisk20-bookworm-pi-install.sh
+++ b/asterisk20-bookworm-pi-install.sh
@@ -15,7 +15,7 @@ echo "Starting Asterisk installation on Raspberry Pi OS (Bookworm)..."
 echo "Step 1: Updating system and installing dependencies..."
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y wget curl gnupg pkg-config build-essential subversion
-sudo apt install -y libedit-dev libssl-dev libjansson-dev libxml2-dev libsqlite3-dev
+sudo apt install -y libedit-dev libssl-dev libjansson-dev libxml2-dev libsqlite3-dev gettext-base
 
 # Ensure system binaries are accessible
 echo "Step 2: Ensuring correct PATH configuration..."
@@ -92,7 +92,9 @@ sudo systemctl start asterisk
 # Installing configuration templates
 echo "Step 13: Installing configuration templates..."
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-sudo cp "$SCRIPT_DIR"/config/*.conf /etc/asterisk/
+for f in "$SCRIPT_DIR"/config/*.conf; do
+    envsubst < "$f" | sudo tee "/etc/asterisk/$(basename "$f")" >/dev/null
+done
 sudo chown asterisk:asterisk /etc/asterisk/*.conf
 
 # Verifying Operation

--- a/asterisk20-install.sh
+++ b/asterisk20-install.sh
@@ -15,7 +15,7 @@ echo "Starting Asterisk installation on Debian 12..."
 echo "Step 1: Updating system and installing dependencies..."
 sudo apt update && sudo apt upgrade -y
 sudo apt install -y wget curl gnupg build-essential subversion
-sudo apt install -y libedit-dev libssl-dev libjansson-dev libxml2-dev libsqlite3-dev
+sudo apt install -y libedit-dev libssl-dev libjansson-dev libxml2-dev libsqlite3-dev gettext-base
 
 # Ensure system binaries are accessible
 echo "Step 2: Ensuring correct PATH configuration..."
@@ -87,7 +87,9 @@ sudo systemctl start asterisk
 # Installing configuration templates
 echo "Step 13: Installing configuration templates..."
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-sudo cp "$SCRIPT_DIR"/config/*.conf /etc/asterisk/
+for f in "$SCRIPT_DIR"/config/*.conf; do
+    envsubst < "$f" | sudo tee "/etc/asterisk/$(basename "$f")" >/dev/null
+done
 sudo chown asterisk:asterisk /etc/asterisk/*.conf
 
 # Verifying Operation

--- a/config/chan_mobile.conf
+++ b/config/chan_mobile.conf
@@ -6,13 +6,13 @@ interval=30                 ; Polling interval in seconds
 ; output of `hcitool dev` or `bluetoothctl list` on your system.
 [adapter]
 id=bt-adapter               ; Identifier used by chan_mobile
-address=00:11:22:33:44:55   ; Bluetooth adapter MAC address
+address=${ADAPTER_MAC}      ; Bluetooth adapter MAC address
 
 ; Mobile phone acting as a trunk. Use `mobile search` from the Asterisk
 ; CLI to discover the device address and RFCOMM port.
 [mobile-trunk]
-address=AA:BB:CC:DD:EE:FF   ; Bluetooth device address
-port=1                      ; RFCOMM channel provided by the phone
+address=${MOBILE_MAC}       ; Bluetooth device address
+port=${MOBILE_PORT}         ; RFCOMM channel provided by the phone
 adapter=bt-adapter          ; Which adapter to use
 context=from-mobile         ; Context for incoming calls
 group=1                     ; Assign to group 1 for hunt group

--- a/config/pjsip.conf
+++ b/config/pjsip.conf
@@ -24,8 +24,8 @@ force_rport=yes
 [yealink-auth]
 type=auth
 auth_type=userpass
-password=SecureP@ssw0rd1
-username=yealink-t42s
+password=${YEALINK_PASSWORD}
+username=${YEALINK_USERNAME}
 
 [yealink-aor]
 type=aor
@@ -48,8 +48,8 @@ force_rport=yes
 [zoiper-auth]
 type=auth
 auth_type=userpass
-password=SecureP@ssw0rd2
-username=zoiper
+password=${ZOIPER_PASSWORD}
+username=${ZOIPER_USERNAME}
 
 [zoiper-aor]
 type=aor
@@ -62,15 +62,15 @@ qualify_frequency=60
 type=registration
 transport=transport-udp
 outbound_auth=sipgate-auth
-client_uri=sip:yourusername@sipgate.co.uk
+client_uri=${SIPGATE_CLIENT_URI}
 server_uri=sip:sipgate.co.uk
 retry_interval=60
 
 [sipgate-auth]
 type=auth
 auth_type=userpass
-password=SipgateTrunkPassword
-username=yourusername
+password=${SIPGATE_PASSWORD}
+username=${SIPGATE_USERNAME}
 
 [sipgate-aor]
 type=aor

--- a/config/settings.sample
+++ b/config/settings.sample
@@ -1,0 +1,13 @@
+# Sample settings for guided Asterisk installation
+YEALINK_USERNAME=yealink-t42s
+YEALINK_PASSWORD=SecureP@ssw0rd1
+ZOIPER_USERNAME=zoiper
+ZOIPER_PASSWORD=SecureP@ssw0rd2
+SIPGATE_USERNAME=yourusername
+SIPGATE_PASSWORD=SipgateTrunkPassword
+SIPGATE_CLIENT_URI=sip:yourusername@sipgate.co.uk
+ADAPTER_MAC=00:11:22:33:44:55
+MOBILE_MAC=AA:BB:CC:DD:EE:FF
+MOBILE_PORT=1
+DB_PASSWORD=secure_password
+

--- a/setup-asterisk.sh
+++ b/setup-asterisk.sh
@@ -4,6 +4,18 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETTINGS_FILE="$SCRIPT_DIR/config/settings.conf"
+
+if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "Settings file not found. Creating default at $SETTINGS_FILE" >&2
+    cp "$SCRIPT_DIR/config/settings.sample" "$SETTINGS_FILE"
+    echo "Edit the file with your environment details and re-run the script." >&2
+    exit 1
+fi
+
+set -a
+source "$SETTINGS_FILE"
+set +a
 
 usage() {
     echo "Usage: $0 [--debian | --pi]" >&2
@@ -44,11 +56,11 @@ sudo pip3 install -r /var/lib/asterisk/agi-bin/asterisk-ivr/requirements.txt
 
 # Create database for the IVR
 echo "Setting up MariaDB database for IVR..."
-sudo mysql <<'EOF'
+sudo mysql <<EOF
 CREATE DATABASE IF NOT EXISTS freepbx_llm;
-CREATE USER IF NOT EXISTS 'freepbx_user'@'localhost' IDENTIFIED BY 'secure_password';
+CREATE USER IF NOT EXISTS 'freepbx_user'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';
 GRANT ALL PRIVILEGES ON freepbx_llm.* TO 'freepbx_user'@'localhost';
 FLUSH PRIVILEGES;
 EOF
 
-echo "Setup complete. Edit /etc/asterisk/pjsip.conf and chan_mobile.conf to set your credentials."
+echo "Setup complete. Configuration was generated from $SETTINGS_FILE."

--- a/tests/setup_asterisk.bats
+++ b/tests/setup_asterisk.bats
@@ -5,6 +5,8 @@ setup() {
   mkdir -p "$TMPDIR/bin"
   cp "$BATS_TEST_DIRNAME/../setup-asterisk.sh" "$TMPDIR/"
   chmod +x "$TMPDIR/setup-asterisk.sh"
+  mkdir -p "$TMPDIR/config"
+  cp "$BATS_TEST_DIRNAME/../config/settings.sample" "$TMPDIR/config/settings.conf"
   cat > "$TMPDIR/asterisk20-install.sh" <<'EOM'
 #!/bin/bash
 echo "DEBIAN_INSTALL"


### PR DESCRIPTION
## Summary
- add `config/settings.sample` for collecting credentials
- apply envsubst templates in install scripts
- load settings file in wrapper script and use for MariaDB setup
- update docs and tests for new configuration flow

## Testing
- `npx bats tests/setup_asterisk.bats`

------
https://chatgpt.com/codex/tasks/task_e_6848770784688323ac890b579efd4313